### PR TITLE
Typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module.exports = {
         loader: "style?css!csslint")
       },
       {
-        scss: /\.scsss$/,
+        scss: /\.scss$/,
         loader: ExtractTextPlugin.extract("style", "css!postcss!csslint!sass")
       }
     ]


### PR DESCRIPTION
Typo in `scss` matching regex.  Removing extra `s`
